### PR TITLE
Add Temple news section to homepage

### DIFF
--- a/exploring-national-parks/src/HomePage.js
+++ b/exploring-national-parks/src/HomePage.js
@@ -4,22 +4,22 @@
  * @module HomePage
  * @returns {JSX.Element} The rendered home page component.
  */
-import React from 'react'
-import Welcome from './HomePage/Components/Welcome'
-import Buttons from './HomePage/Components/Buttons'
-import yosemite from './HomePage/Assets/yosemite.jpg';
-import './Style/homepage.css'
+import React from 'react';
+import Welcome from './HomePage/Components/Welcome';
+import TempleNews from './HomePage/Components/TempleNews';
+import Buttons from './HomePage/Components/Buttons';
+import './Style/homepage.css';
 import HighlightGallery from './HomePage/Components/HighlightGallery';
+
 const HomePage = () => {
   return (
-    // <Navbar/>
-    <div className = "home-page main-component">
-        {/* <h1>Test Hello</h1> */}
-        <Welcome/>
-        <HighlightGallery/>
-        <Buttons/>
+    <div className="home-page main-component">
+      <Welcome />
+      <TempleNews />
+      <HighlightGallery />
+      <Buttons />
     </div>
-  )
-}
+  );
+};
 
-export default HomePage
+export default HomePage;

--- a/exploring-national-parks/src/HomePage/Components/TempleNews.jsx
+++ b/exploring-national-parks/src/HomePage/Components/TempleNews.jsx
@@ -1,0 +1,215 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import moment from 'moment';
+
+/**
+ * Endpoints that expose the latest alerts and headlines from Temple.
+ *
+ * We rely on r.jina.ai as a lightweight proxy that adds permissive CORS headers
+ * around the upstream RSS feeds so that they can be consumed directly from the
+ * browser without exposing API secrets.
+ */
+const TEMPLE_FEEDS = [
+  {
+    label: 'Temple Alert on Twitter',
+    url: 'https://r.jina.ai/https://nitter.net/TempleAlert/rss',
+    canonicalProfile: 'https://twitter.com/TempleAlert',
+  },
+  {
+    label: 'Temple University on Twitter',
+    url: 'https://r.jina.ai/https://nitter.net/templeuniv/rss',
+    canonicalProfile: 'https://twitter.com/templeuniv',
+  },
+  {
+    label: 'Temple University News',
+    url: 'https://r.jina.ai/https://news.temple.edu/rss.xml',
+    canonicalProfile: 'https://news.temple.edu/',
+  },
+];
+
+const formatPublishedDate = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  const parsed = moment(new Date(value));
+  if (!parsed.isValid()) {
+    return '';
+  }
+
+  return parsed.local().format('MMM D, YYYY h:mm A');
+};
+
+const normaliseLink = (link) => {
+  if (!link) {
+    return '';
+  }
+
+  try {
+    const url = new URL(link);
+    if (url.hostname.includes('nitter.net')) {
+      return `https://twitter.com${url.pathname}`;
+    }
+
+    return url.toString();
+  } catch (error) {
+    console.warn('Unable to normalise Temple news link', link, error);
+    return link;
+  }
+};
+
+const extractFeedItems = (doc) => {
+  if (!doc) {
+    return [];
+  }
+
+  const nodes = Array.from(doc.querySelectorAll('item'));
+  return nodes.map((item) => {
+    const title = item.querySelector('title')?.textContent?.trim() ?? '';
+    const link = item.querySelector('link')?.textContent?.trim() ?? '';
+    const pubDate = item.querySelector('pubDate')?.textContent?.trim() ?? '';
+    const guid = item.querySelector('guid')?.textContent?.trim() ?? '';
+
+    return {
+      id: guid || link || title,
+      title,
+      link,
+      pubDate,
+    };
+  });
+};
+
+const parseFeedResponse = async (response) => {
+  const text = await response.text();
+  const parser = new window.DOMParser();
+  return parser.parseFromString(text, 'text/xml');
+};
+
+/**
+ * Displays the most recent alerts and news headlines for Temple University.
+ *
+ * The component iterates through a list of Temple news feeds and renders the
+ * first feed that successfully returns at least one item. This approach allows
+ * the UI to fall back from the Temple Alert feed to the official Temple
+ * University account (or even the newsroom RSS feed) if one of the sources is
+ * temporarily unavailable.
+ *
+ * @component
+ * @memberof HomePage
+ * @returns {JSX.Element}
+ */
+const TempleNews = ({ maxItems = 5 }) => {
+  const [items, setItems] = useState([]);
+  const [status, setStatus] = useState('loading');
+  const [activeSource, setActiveSource] = useState(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    let isMounted = true;
+    const controller = new AbortController();
+
+    const fetchTempleNews = async () => {
+      for (const feed of TEMPLE_FEEDS) {
+        try {
+          const response = await fetch(feed.url, {
+            signal: controller.signal,
+            headers: {
+              Accept: 'application/rss+xml, application/xml, text/xml',
+            },
+          });
+
+          if (!response.ok) {
+            throw new Error(`Unable to load Temple news from ${feed.url}`);
+          }
+
+          const xml = await parseFeedResponse(response);
+          const parsedItems = extractFeedItems(xml)
+            .filter((item) => item.title && item.link)
+            .slice(0, maxItems)
+            .map((item) => ({
+              ...item,
+              link: normaliseLink(item.link),
+              pubDateFormatted: formatPublishedDate(item.pubDate),
+            }));
+
+          if (parsedItems.length > 0) {
+            if (isMounted) {
+              setItems(parsedItems);
+              setActiveSource(feed);
+              setStatus('ready');
+            }
+            return;
+          }
+        } catch (error) {
+          console.error('Temple news feed error:', error);
+        }
+      }
+
+      if (isMounted) {
+        setItems([]);
+        setStatus('empty');
+        setErrorMessage('No live Temple updates are available right now. Please check back soon.');
+      }
+    };
+
+    fetchTempleNews();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [maxItems]);
+
+  const content = useMemo(() => {
+    if (status === 'loading') {
+      return <p className="temple-news__status">Loading the latest updates…</p>;
+    }
+
+    if (status !== 'ready') {
+      return (
+        <p className="temple-news__status temple-news__status--error">{errorMessage}</p>
+      );
+    }
+
+    return (
+      <ul className="temple-news__list">
+        {items.map((item) => (
+          <li key={item.id} className="temple-news__item">
+            <a
+              className="temple-news__link"
+              href={item.link}
+              target="_blank"
+              rel="noreferrer"
+            >
+              <span className="temple-news__title">{item.title}</span>
+              {item.pubDateFormatted && (
+                <span className="temple-news__date">{item.pubDateFormatted}</span>
+              )}
+            </a>
+          </li>
+        ))}
+      </ul>
+    );
+  }, [errorMessage, items, status]);
+
+  return (
+    <section className="temple-news" aria-labelledby="temple-news-heading">
+      <div className="temple-news__inner">
+        <h2 id="temple-news-heading" className="temple-news__heading">
+          Temple Alerts &amp; Headlines
+        </h2>
+        <p className="temple-news__intro">
+          Stay up to date with the latest alerts and announcements from Temple University
+          while you plan your next outdoor adventure.
+        </p>
+        {activeSource && status === 'ready' && (
+          <p className="temple-news__source">
+            Source: <a href={activeSource.canonicalProfile} target="_blank" rel="noreferrer">{activeSource.label}</a>
+          </p>
+        )}
+        {content}
+      </div>
+    </section>
+  );
+};
+
+export default TempleNews;

--- a/exploring-national-parks/src/Style/homepage.css
+++ b/exploring-national-parks/src/Style/homepage.css
@@ -139,3 +139,123 @@
         filter:brightness(80%)blur(0.5px);
     }
 }
+
+.temple-news {
+    max-width: 960px;
+    margin: 3rem auto;
+    color: white;
+    background-color: rgba(0, 0, 0, 0.65);
+    border-radius: 18px;
+    padding: 2.5rem 3rem;
+    box-shadow: 0 25px 40px rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(2px);
+}
+
+.temple-news__inner {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.temple-news__heading {
+    font-size: 3.5rem;
+    margin: 0;
+    text-align: center;
+}
+
+.temple-news__intro {
+    margin: 0;
+    font-size: 1.25rem;
+    line-height: 1.75;
+    text-align: center;
+}
+
+.temple-news__source {
+    margin: 0;
+    text-align: center;
+    font-size: 1rem;
+}
+
+.temple-news__source a {
+    color: #e5bb73;
+    font-weight: 600;
+}
+
+.temple-news__list {
+    list-style: none;
+    display: grid;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+
+.temple-news__item {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 1rem 1.5rem;
+    transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.temple-news__item:hover {
+    background: rgba(255, 255, 255, 0.18);
+    transform: translateY(-2px);
+}
+
+.temple-news__link {
+    color: inherit;
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.temple-news__title {
+    font-size: 1.2rem;
+    font-weight: 600;
+    line-height: 1.45;
+}
+
+.temple-news__date {
+    font-size: 0.95rem;
+    opacity: 0.85;
+}
+
+.temple-news__status {
+    font-size: 1.05rem;
+    text-align: center;
+    margin: 0;
+}
+
+.temple-news__status--error {
+    color: #ffdede;
+}
+
+@media (max-width: 960px) {
+    .temple-news {
+        margin: 2rem 1.25rem;
+        padding: 2rem 1.75rem;
+    }
+
+    .temple-news__heading {
+        font-size: 2.75rem;
+    }
+
+    .temple-news__intro {
+        font-size: 1.1rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .temple-news {
+        margin: 1.5rem 1rem;
+        padding: 1.5rem 1.25rem;
+    }
+
+    .temple-news__heading {
+        font-size: 2.25rem;
+    }
+
+    .temple-news__title {
+        font-size: 1.05rem;
+    }
+}


### PR DESCRIPTION
## Summary
- add a TempleNews homepage component that pulls the latest Temple alerts and headlines
- surface the new feed on the homepage and style it to stand out on top of the hero background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f908b332648321a0d3a760921a3912